### PR TITLE
Add scipy package for scipy-base

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -41,7 +41,7 @@ RUN apt update -qq && \
 RUN pip install nbgitpuller && \
     jupyter serverextension enable --py nbgitpuller --sys-prefix
 
-RUN mamba install -y -c conda-forge pandas numpy matplotlib 
+RUN mamba install -y -c conda-forge pandas numpy matplotlib scipy
 
 USER $NB_USER
 


### PR DESCRIPTION
The readme seems to indicate that this builds the jupyter-base and scipy-base images, but the scipy package is missing. Let's add it so the scipy-base:latest will have the scipy package. 