### PR TITLE
Bugfix/jenkins var scope

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+def CONT = "true"
+
 pipeline {
     agent none
     triggers { cron('H H(0-6) * * 1') }
@@ -25,9 +27,6 @@ pipeline {
                     stage('Build Test Deploy') {
                         agent {
                             label "${AGENT}"
-                        }
-                        environment {
-                            CONT = "true"
                         }
                         stages{
                             stage('Build') {


### PR DESCRIPTION
Variable scope fix to make the ARM build failover actually work so it won't fail for x86.