### PR TITLE
Fix home perms

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -43,6 +43,8 @@ RUN pip install nbgitpuller && \
 RUN mamba install -y -c conda-forge pandas numpy matplotlib jupyterthemes && \
     mamba clean --all
 
+RUN chown -R jovyan:users /home/jovyan
+
 USER $NB_USER
 
 RUN git lfs install


### PR DESCRIPTION
Somehow the perms on /home/jovyan are screwed up in the new images.  This should fix it.

```
podman run --rm -it --entrypoint=bash ucsb/jupyter-base:latest 
bash: /home/jovyan/.bashrc: Permission denied
jovyan@affdb1d08dc1:~$ ls -l
ls: cannot open directory '.': Permission denied
jovyan@affdb1d08dc1:~$ pwd
/home/jovyan
```