### PR TITLE
Refactor for MultiArch Manifests And Bump Jupyter Version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         JUPYTER_VERSION = '7.4.5'
     }
     stages {
-        stage('Jupyter Images') {
+        stage('Jupyter Image Builds') {
             matrix {
                 axes {
                     axis {
@@ -130,7 +130,7 @@ pipeline {
                                     ).trim()}"""     
                                     IMG_SUFFIX = """${sh(
                                         returnStdout: true,
-                                        script: '[ "jupyter-arm" == "$AGENT" ] && echo "-aarch64" || echo ""'
+                                        script: '[ "jupyter-arm" == "$AGENT" ] && echo "-aarch64" || echo "-arm64"'
                                     ).trim()}"""                                    
                                 }
                                 stages{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,16 +170,40 @@ pipeline {
                 DOCKER_HUB_CREDS = credentials('DockerHubToken')
             }
             steps {
-                //FIXME This is copied from a single user image, but we need to replace the IMAGE_NAME var here because this build does multiple image names because of the Matrix, which this is outside of.
-                sh 'podman manifest create $IMAGE_NAME:latest'
-                sh 'podman manifest add $IMAGE_NAME:latest docker://docker.io/ucsb/$IMAGE_NAME:latest-aarch64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
-                sh 'podman manifest add $IMAGE_NAME:latest docker://docker.io/ucsb/$IMAGE_NAME:latest-amd64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
-                sh 'podman manifest push $IMAGE_NAME:latest docker://docker.io/ucsb/$IMAGE_NAME:latest --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
-                sh 'podman manifest push $IMAGE_NAME:latest docker://docker.io/ucsb/$IMAGE_NAME:v$(date "+%Y%m%d") --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                //In Theory this only happens when all of the other stages have already deployed. There should be jupyter-base, scipy-base and pytorch-base images with date codes that match latest at this point, and weekly tags for all of those as well. Pytorch has a cuda prefix as well, but we should probably make a simple latest tag that uses the most recent cuda version. 
+                //Create manifest for jupyter-base from existing tags and push to latest and datecode tags. 
+                sh 'podman manifest create jupyter-base:latest'
+                sh 'podman manifest add jupyter-base:latest docker://docker.io/ucsb/jupyter-base:latest-aarch64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest add jupyter-base:latest docker://docker.io/ucsb/jupyter-base:latest-amd64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push jupyter-base:latest docker://docker.io/ucsb/jupyter-base:latest --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push jupyter-base:latest docker://docker.io/ucsb/jupyter-base:v$(date "+%Y%m%d") --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                //Create manifest for scipy-base from existing tags. 
+                sh 'podman manifest create scipy-base:latest'
+                sh 'podman manifest add scipy-base:latest docker://docker.io/ucsb/scipy-base:latest-aarch64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest add scipy-base:latest docker://docker.io/ucsb/scipy-base:latest-amd64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push scipy-base:latest docker://docker.io/ucsb/scipy-base:latest --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push scipy-base:latest docker://docker.io/ucsb/scipy-base:v$(date "+%Y%m%d") --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                //Create manifest for cuda12-pytorch-base from existing tags. 
+                sh 'podman manifest create cuda12-pytorch-base:latest'
+                sh 'podman manifest add cuda12-pytorch-base:latest docker://docker.io/ucsb/cuda12-pytorch-base:latest-aarch64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest add cuda12-pytorch-base:latest docker://docker.io/ucsb/cuda12-pytorch-base:latest-amd64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push cuda12-pytorch-base:latest docker://docker.io/ucsb/cuda12-pytorch-base:latest --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push cuda12-pytorch-base:latest docker://docker.io/ucsb/cuda12-pytorch-base:v$(date "+%Y%m%d") --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                //Create manifest for cuda13-pytorch-base and pytorch-base (since Cuda13 is latest) from existing tags. 
+                sh 'podman manifest create cuda13-pytorch-base:latest'
+                sh 'podman manifest add cuda13-pytorch-base:latest docker://docker.io/ucsb/cuda13-pytorch-base:latest-aarch64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest add cuda13-pytorch-base:latest docker://docker.io/ucsb/cuda13-pytorch-base:latest-amd64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push cuda13-pytorch-base:latest docker://docker.io/ucsb/cuda13-pytorch-base:latest --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push cuda13-pytorch-base:latest docker://docker.io/ucsb/cuda13-pytorch-base:v$(date "+%Y%m%d") --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push cuda13-pytorch-base:latest docker://docker.io/ucsb/pytorch-base:latest --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push cuda13-pytorch-base:latest docker://docker.io/ucsb/pytorch-base:v$(date "+%Y%m%d") --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
             }
             post {
                 always {
-                    sh 'podman manifest rm $IMAGE_NAME:latest || true'
+                    sh 'podman manifest rm jupyter-base:latest || true'
+                    sh 'podman manifest rm scipy-base:latest || true'
+                    sh 'podman manifest rm pytorch-base:cuda12-latest || true'
+                    sh 'podman manifest rm pytorch-base:cuda13-latest || true'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                     }
                     axis {
                         name 'CUDA_VER'
-                        values 'none', 'cuda11', 'cuda12'
+                        values 'none', 'cuda12', 'cuda13'
                     }
                 }
                 excludes {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent none
     triggers { cron('H H(0-2) * * 1') }
     environment {
-        JUPYTER_VERSION = '7.4.5'
+        JUPYTER_VERSION = '7.5.3'
     }
     stages {
         stage('Jupyter Image Builds') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
                                 environment {
                                     IMG_PREFIX = """${sh(
                                         returnStdout: true,
-                                        script: '[ "jupyter-arm" == "$AGENT" ] && echo "aarch64-" || ( [ "pytorch-base" == "$IMAGE_NAME" -a "$CUDA_VER" != "none" ] && echo "${CUDA_VER}-" ||  echo "" )'
+                                        script: '[ "pytorch-base" == "$IMAGE_NAME" -a "$CUDA_VER" != "none" ] && echo "${CUDA_VER}-" ||  echo "" '
                                     ).trim()}"""
                                     IMG_BASE = """${sh(
                                         returnStdout: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,6 +163,26 @@ pipeline {
                 }
             }
         }
+        stage('Latest and Datecode Manifests') {
+            when { branch 'main' }
+            agent { label 'podman' }
+            environment {
+                DOCKER_HUB_CREDS = credentials('DockerHubToken')
+            }
+            steps {
+                //FIXME This is copied from a single user image, but we need to replace the IMAGE_NAME var here because this build does multiple image names because of the Matrix, which this is outside of.
+                sh 'podman manifest create $IMAGE_NAME:latest'
+                sh 'podman manifest add $IMAGE_NAME:latest docker://docker.io/ucsb/$IMAGE_NAME:latest-aarch64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest add $IMAGE_NAME:latest docker://docker.io/ucsb/$IMAGE_NAME:latest-amd64 --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push $IMAGE_NAME:latest docker://docker.io/ucsb/$IMAGE_NAME:latest --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+                sh 'podman manifest push $IMAGE_NAME:latest docker://docker.io/ucsb/$IMAGE_NAME:v$(date "+%Y%m%d") --creds $DOCKER_HUB_CREDS_USR:$DOCKER_HUB_CREDS_PSW'
+            }
+            post {
+                always {
+                    sh 'podman manifest rm $IMAGE_NAME:latest || true'
+                }
+            }
+        }
     }
     post {
         success {


### PR DESCRIPTION
It would be good if we were pushing multiple manifests for the latest and date tags so that some commands will work regardless if users are on arm or amd arches. 

Few other notes: 

- Upstream has moved on from cuda11 to cuda13. 
- Upstream has also adopted multi-arch manifests so we shouldn't need the aarch64 prefix anymore for cuda tags. 
- We might consider a manifest copy for latest-<arch> instead of two skopeo copies given how "stable" the repo can be?